### PR TITLE
Upgrade Kodein to v5.0.0.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,9 +31,9 @@ dependencies {
   compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
   compile 'com.android.support:appcompat-v7:26.1.0'
   compile 'com.android.support.constraint:constraint-layout:1.0.2'
-  compile 'com.github.salomonbrys.kodein:kodein:4.1.0'
-  compile 'com.github.salomonbrys.kodein:kodein-android:4.1.0'
-  compile 'com.github.salomonbrys.kodein:kodein-conf:4.1.0'
+  compile 'org.kodein.di:kodein-di-generic-jvm:5.0.0'
+  compile 'org.kodein.di:kodein-di-framework-android:5.0.0'
+  compile 'org.kodein.di:kodein-di-conf-jvm:5.0.0'
   androidTestCompile 'com.android.support.test:runner:1.0.1'
   androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.1'
   androidTestCompile 'org.mockito:mockito-android:2.13.0'

--- a/app/src/androidTest/java/com/karumi/kodein/sample/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/karumi/kodein/sample/MainActivityTest.kt
@@ -9,14 +9,14 @@ import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
 import android.support.test.espresso.matcher.ViewMatchers.withText
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
-import com.github.salomonbrys.kodein.Kodein.Module
-import com.github.salomonbrys.kodein.bind
-import com.github.salomonbrys.kodein.instance
 import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.kodein.di.Kodein.Module
+import org.kodein.di.generic.bind
+import org.kodein.di.generic.instance
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 

--- a/app/src/main/java/com/karumi/kodein/sample/KodeinSampleApp.kt
+++ b/app/src/main/java/com/karumi/kodein/sample/KodeinSampleApp.kt
@@ -2,11 +2,11 @@ package com.karumi.kodein.sample
 
 import android.app.Application
 import android.content.Context
-import com.github.salomonbrys.kodein.Kodein.Module
-import com.github.salomonbrys.kodein.KodeinAware
-import com.github.salomonbrys.kodein.bind
-import com.github.salomonbrys.kodein.conf.ConfigurableKodein
-import com.github.salomonbrys.kodein.singleton
+import org.kodein.di.Kodein.Module
+import org.kodein.di.KodeinAware
+import org.kodein.di.conf.ConfigurableKodein
+import org.kodein.di.generic.bind
+import org.kodein.di.generic.singleton
 
 class KodeinSampleApp : Application(), KodeinAware {
     override val kodein = ConfigurableKodein(mutable = true)

--- a/app/src/main/java/com/karumi/kodein/sample/MainActivity.kt
+++ b/app/src/main/java/com/karumi/kodein/sample/MainActivity.kt
@@ -1,18 +1,22 @@
 package com.karumi.kodein.sample
 
 import android.os.Bundle
-import com.github.salomonbrys.kodein.Kodein.Module
-import com.github.salomonbrys.kodein.android.KodeinAppCompatActivity
-import com.github.salomonbrys.kodein.bind
-import com.github.salomonbrys.kodein.instance
-import com.github.salomonbrys.kodein.provider
+import android.support.v7.app.AppCompatActivity
 import kotlinx.android.synthetic.main.activity_main.tv_name_activity_scope
 import kotlinx.android.synthetic.main.activity_main.tv_name_app_scope
+import org.kodein.di.Kodein
+import org.kodein.di.KodeinAware
+import org.kodein.di.android.closestKodein
+import org.kodein.di.generic.bind
+import org.kodein.di.generic.instance
+import org.kodein.di.generic.provider
 
-class MainActivity : KodeinAppCompatActivity() {
+class MainActivity : AppCompatActivity(), KodeinAware {
 
-    private val applicationScopeClass: ApplicationScopeClass by injector.instance()
-    private val activityScopeClass: ActivityScopeClass by injector.instance()
+    override val kodein by closestKodein()
+
+    private val applicationScopeClass: ApplicationScopeClass by instance()
+    private val activityScopeClass: ActivityScopeClass by instance()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         applicationContext.asApp().addModule(activityModules)
@@ -27,7 +31,7 @@ class MainActivity : KodeinAppCompatActivity() {
         tv_name_activity_scope.text = activityScopeClass.getText()
     }
 
-    private val activityModules = Module(allowSilentOverride = true) {
+    private val activityModules = Kodein.Module(allowSilentOverride = true) {
         bind<ActivityScopeClass>() with provider {
             ActivityScopeClass()
         }


### PR DESCRIPTION
As Kodein has released a major upgrade (and all source code and documentation from previous releases has been totally removed), we should consider Kodein v4.x.x and earlier as deprecated.

Here is my proposed upgrade. Application and test classes just need some import replacements, MainActivity requires a bit more as Android library support has been completely revamped and `KodeinAppCompatActivity` and more classes are now gone.

Instead, we will use `closestKodein` from `KodeinAware` interface, so we will just need `instance()` to retrieve our dependencies. See http://kodein.org/Kodein-DI/?5.0/android#_retrieving for further reference.